### PR TITLE
fix file info delete query

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -427,8 +427,8 @@ func (s *SQLStore) deleteBlockAndChildren(db sq.BaseRunner, blockID string, modi
 
 	if fileID != "" {
 		deleteFileInfoQuery := s.getQueryBuilder(db).
-			Update("FileInfo").
-			Set("DeleteAt", model.GetMillis()).
+			Update("file_info").
+			Set("delete_at", model.GetMillis()).
 			Where(sq.Eq{"id": fileID})
 		if _, err := deleteFileInfoQuery.Exec(); err != nil {
 			return err
@@ -984,8 +984,8 @@ func (s *SQLStore) deleteBlockChildren(db sq.BaseRunner, boardID string, parentI
 
 	if len(fileIDs) > 0 {
 		deleteFileInfoQuery := s.getQueryBuilder(db).
-			Update("FileInfo").
-			Set("DeleteAt", model.GetMillis()).
+			Update("file_info").
+			Set("delete_at", model.GetMillis()).
 			Where(sq.Eq{"id": fileIDs})
 
 		if _, err := deleteFileInfoQuery.Exec(); err != nil {


### PR DESCRIPTION
#### Summary
title.


#### Ticket Link
introduced in #4746, fixes #4947


#### Additional Information
I've not touched the bad query in [mm auth layer](https://github.com/mattermost-community/focalboard/blob/de5e5cc4141f14f69bf0e5666383997b81f851d6/server/services/store/mattermostauthlayer/mattermostauthlayer.go#L539-L561) because the schema is too different from the correct schema for the `file_info` table.
```sql
CREATE TABLE file_info (
    id varchar(26) NOT NULL,
    create_at BIGINT NOT NULL,
    delete_at BIGINT,
    name TEXT NOT NULL,
    extension VARCHAR(50) NOT NULL,
    size BIGINT NOT NULL,
    archived BOOLEAN
, path varchar(512));
```